### PR TITLE
Adding bopscrk command

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,4 +15,9 @@ setup(
     packages=['modules',],
     scripts=['bopscrk.py'],
     install_requires=['requests'],
+    entry_points = {
+        'console_scripts':[
+            'bopscrk = modules.main:run'
+        ]
+    }
 )


### PR DESCRIPTION
Hello,
I have added `bopscrk` command to run `bopscrk` instead of `python3 bopscrk.py`. 
Can you post `bopscrk` in [pypi](https://pypi.org/search/?q=bopscrk), to enable installation using pip and use it in other projects?